### PR TITLE
fix: Remove signature image and update social media section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -265,15 +265,8 @@ nav ul li a:hover {
 }
 
 /* Social Media Section */
-.social-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 1rem;
-}
-
-.social-item img {
-    width: 100%;
-    height: auto;
+.social-links {
+    text-align: center;
 }
 
 /* Footer */

--- a/index.html
+++ b/index.html
@@ -38,7 +38,6 @@
                 <div class="about-content">
                     <div class="about-text">
                         <p>Stephanie P. Kirk is a digital creator and author. She has been working as an Instructor since 2013. She studied at Regent University (Class of 1991) and Southern University (1984-1987). She graduated from Opelousas Senior High School in 1984. Born on May 24, 1966, Stephanie is a passionate writer and educator.</p>
-                        <img src="https://via.placeholder.com/200x50.png?text=Signature" alt="Signature" class="signature">
                     </div>
                     <div class="about-photo">
                         <img src="https://i.ibb.co/DHXbBm0Q/aaa496944280-3715363958608635-8536620574682671310-n.jpg" alt="Stephanie P. Kirk">
@@ -104,12 +103,8 @@
         <section id="social" class="social-section content-section bg-white">
             <div class="container">
                 <h2>Follow Me</h2>
-                <div class="social-grid">
-                    <!-- Placeholder for social media feed -->
-                    <div class="social-item"><img src="https://via.placeholder.com/300x300.png?text=Post+1" alt="Social Media Post 1"></div>
-                    <div class="social-item"><img src="https://via.placeholder.com/300x300.png?text=Post+2" alt="Social Media Post 2"></div>
-                    <div class="social-item"><img src="https://via.placeholder.com/300x300.png?text=Post+3" alt="Social Media Post 3"></div>
-                    <div class="social-item"><img src="https://via.placeholder.com/300x300.png?text=Post+4" alt="Social Media Post 4"></div>
+                <div class="social-links">
+                    <a href="https://www.facebook.com/stephanie.kirk.507" target="_blank" class="btn">Follow on Facebook</a>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
This commit addresses user feedback on the new design.

- The placeholder signature image has been removed from the 'About the Author' section to prevent a broken image icon from displaying.
- The social media grid has been replaced with a single, centered link to the author's Facebook page as requested.