### PR TITLE
fix: Update hero background image to a more suitable one

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -103,7 +103,7 @@ nav ul li a:hover {
 /* Hero Section */
 .hero-section {
     height: 100vh;
-    background: url('https://i.ibb.co/6gBsC4B/aaa-author-workspace.jpg') no-repeat center center/cover;
+    background: url('https://freerangestock.com/sample/61754/vintage-typewriter-in-black-and-white.jpg') no-repeat center center/cover;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
This commit replaces the placeholder background image in the hero section with a more thematically appropriate image of a vintage typewriter. This change addresses the feedback from the code review and better aligns with the website's intended aesthetic.